### PR TITLE
Feat/persist data

### DIFF
--- a/TarkovSauce.Client/Components/Layout/MainLayout.razor
+++ b/TarkovSauce.Client/Components/Layout/MainLayout.razor
@@ -1,9 +1,8 @@
 ﻿@using Microsoft.Extensions.Configuration
 @using TarkovSauce.Client.Services
 @using TarkovSauce.Client.Utils
+@using TarkovSauce.Watcher
 @inherits LayoutComponentBase
-@inject StateContainer StateContainer
-@inject AppDataJson AppDataJson
 
 <div class="page">
     <div class="sidebar">
@@ -20,22 +19,9 @@
             @Body
         </article>
     </main>
-    <TarkovSauce.Client.Components.Modal.TSToast />
+    @if (!Monitor.IsLoading)
+    {
+        <TarkovSauce.Client.Components.Modal.TSToast />
+    }
     <TarkovSauce.Client.Components.Misc.TSSPinner @bind-IsSpinning=StateContainer.IsLoading.Value />
 </div>
-
-@code {
-    protected override void OnInitialized()
-    {
-        StateContainer.IsLoading.OnValueChanged += b => InvokeAsync(StateHasChanged);
-        StateContainer.MainLayoutChangedEvent += () => InvokeAsync(StateHasChanged);
-    }
-    private void LaunchApp()
-    {
-        if (!string.IsNullOrEmpty(AppDataJson.Settings.TarkovExePath))
-        {
-            // Use Process.Start to launch the Tarkov application
-            System.Diagnostics.Process.Start(AppDataJson.Settings.TarkovExePath);
-        }
-    }
-}

--- a/TarkovSauce.Client/Components/Layout/MainLayout.razor.cs
+++ b/TarkovSauce.Client/Components/Layout/MainLayout.razor.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.AspNetCore.Components;
+using TarkovSauce.Client.Services;
+using TarkovSauce.Client.Utils;
+using TarkovSauce.Watcher;
+
+namespace TarkovSauce.Client.Components.Layout
+{
+    public partial class MainLayout
+    {
+        [Inject]
+        public StateContainer StateContainer { get; set; } = default!;
+        [Inject]
+        public AppDataJson AppDataJson { get; set; } = default!;
+        [Inject]
+        public IMonitor Monitor { get; set; } = default!;
+        protected override void OnInitialized()
+        {
+            StateContainer.IsLoading.OnValueChanged += b => InvokeAsync(StateHasChanged);
+            StateContainer.MainLayoutChangedEvent += () => InvokeAsync(StateHasChanged);
+            Monitor.IsLoadingChanged += b =>
+            {
+                StateContainer.IsLoading.Value = b;
+            };
+            Task.Run(() =>
+            {
+                Monitor.GoToCheckpoint();
+            });
+        }
+        protected override async Task OnInitializedAsync()
+        {
+            await base.OnInitializedAsync();
+        }
+        private void LaunchApp()
+        {
+            if (!string.IsNullOrEmpty(AppDataJson.Settings.TarkovExePath))
+            {
+                // Use Process.Start to launch the Tarkov application
+                System.Diagnostics.Process.Start(AppDataJson.Settings.TarkovExePath);
+            }
+        }
+    }
+}

--- a/TarkovSauce.Client/Components/Pages/FleaSales.razor
+++ b/TarkovSauce.Client/Components/Pages/FleaSales.razor
@@ -10,7 +10,7 @@
             <th>Value</th>
         </tr>
 
-        @foreach (var item in FleaSalesProvider.Events)
+        @foreach (var item in FleaSalesProvider.Events.OrderByDescending(ev => ev.Id))
         {
             <tr>
                 <td>@item.Type</td>

--- a/TarkovSauce.Client/Components/Pages/FleaSales.razor
+++ b/TarkovSauce.Client/Components/Pages/FleaSales.razor
@@ -4,15 +4,17 @@
 <div class="tstable">
     <table class="flea-sales-table">
         <tr>
+            <th>Timestamp</th>
             <th>Type</th>
             <th>Item</th>
             <th>Quantity</th>
             <th>Value</th>
         </tr>
 
-        @foreach (var item in FleaSalesProvider.Events.OrderByDescending(ev => ev.Id))
+        @foreach (var item in FleaSalesProvider.Events.OrderByDescending(ev => ev.Timestamp))
         {
             <tr>
+                <td>@item.Timestamp.ToString("G")</td>
                 <td>@item.Type</td>
                 <td>@item.ItemName</td>
                 <td>@item.Quantity</td>

--- a/TarkovSauce.Client/Components/Pages/TasksPage.razor.cs
+++ b/TarkovSauce.Client/Components/Pages/TasksPage.razor.cs
@@ -37,28 +37,9 @@ namespace TarkovSauce.Client.Components.Pages
                 StateContainer.TasksCache = await DevHttpClient.GetTasksBatch();
             }
 
-            var tasks = StateContainer.TasksCache?.Data?.Tasks?
-                .Where(task => task.MinPlayerLevel <= progress?.Data.PlayerLevel)
-                .Where(task => !progress?.Data.TasksProgress.Any(tp => tp.Id == task.Id) ?? false)
-                .Where(task => task.TraderRequirements.Length == 0)
-                ?? [];
-
-            List<TaskModel> results = [];
-            foreach (var task in tasks)
-            {
-                bool skip = false;
-                foreach (var req in task.TaskRequirements)
-                {
-                    if (!progress?.Data.TasksProgress.Any(tp => tp.Id == req.Task.Id) ?? false)
-                    {
-                        skip = true;
-                        break;
-                    }
-                }
-                if (skip) continue;
-                results.Add(task);
-            }
-            _tasks = results;
+            _tasks = StateContainer.TasksCache?.Data?.Tasks?
+                .Where(task => progress?.Data.TasksProgress
+                    .Any(tp => tp.Id == task.Id && !tp.Complete && !tp.Failed && !tp.Invalid) ?? false);
         }
 
         private bool TestForMap(TaskModel model)

--- a/TarkovSauce.Client/Data/EventArgs/FleaExpiredeMessageEventArgs.cs
+++ b/TarkovSauce.Client/Data/EventArgs/FleaExpiredeMessageEventArgs.cs
@@ -2,7 +2,7 @@
 {
     public class FleaExpiredeMessageEventArgs : JsonEventArgs
     {
-        public string ItemId => Message.Items.Data[0].Id;
+        public string ItemId => Message.Items.Data[0].Tpl;
         public string ItemIdMask { get; set; } = "";
         public int ItemCount => Message.Items.Data[0].Upd?.StackObjectsCount ?? 1;
         public SystemChatMessageWithItems Message { get; set; } = new();

--- a/TarkovSauce.Client/Data/EventArgs/FleaMarketSoldChatMessage.cs
+++ b/TarkovSauce.Client/Data/EventArgs/FleaMarketSoldChatMessage.cs
@@ -1,9 +1,12 @@
-﻿using TarkovSauce.Client.Data.Models;
+﻿using System.Text.Json.Serialization;
+using TarkovSauce.Client.Data.Models;
 
 namespace TarkovSauce.Client.Data.EventArgs
 {
     public class FleaMarketSoldChatMessage : SystemChatMessageWithItems
     {
         public FleaSoldData SystemData { get; set; } = new();
+        [JsonPropertyName("dt")]
+        public new long Timestamp { get; set; }
     }
 }

--- a/TarkovSauce.Client/Data/EventArgs/SystemChatMessageWithItems.cs
+++ b/TarkovSauce.Client/Data/EventArgs/SystemChatMessageWithItems.cs
@@ -1,9 +1,12 @@
-﻿using TarkovSauce.Client.Data.Models;
+﻿using System.Text.Json.Serialization;
+using TarkovSauce.Client.Data.Models;
 
 namespace TarkovSauce.Client.Data.EventArgs
 {
     public class SystemChatMessageWithItems : SystemChatMessage
     {
         public MessageItems Items { get; set; } = new();
+        [JsonPropertyName("dt")]
+        public long Timestamp { get; set; }
     }
 }

--- a/TarkovSauce.Client/Data/Models/Remote/ItemModel.cs
+++ b/TarkovSauce.Client/Data/Models/Remote/ItemModel.cs
@@ -1,7 +1,10 @@
-﻿namespace TarkovSauce.Client.Data.Models.Remote
+﻿using SQLite;
+
+namespace TarkovSauce.Client.Data.Models.Remote
 {
     public class ItemModel
     {
+        [PrimaryKey]
         public string Id { get; set; } = "";
         public string Name { get; set; } = "";
     }

--- a/TarkovSauce.Client/Data/Models/Remote/TaskModel.cs
+++ b/TarkovSauce.Client/Data/Models/Remote/TaskModel.cs
@@ -1,4 +1,6 @@
-﻿namespace TarkovSauce.Client.Data.Models.Remote
+﻿using SQLite;
+
+namespace TarkovSauce.Client.Data.Models.Remote
 {
     public class TaskModel
     {
@@ -9,6 +11,16 @@
         public TaskRequirementsModel[] TaskRequirements { get; set; } = [];
         public TraderModel Trader { get; set; } = new();
         public TraderRequirementsModel[] TraderRequirements { get; set; } = [];
+    }
+    public class TaskModelFlat
+    {
+        public string Id { get; set; } = "";
+        public string Name { get; set; } = "";
+        public int MinPlayerLevel { get; set; }
+        public string Objectives { get; set; } = "";
+        public string TaskRequirements { get; set; } = "";
+        public string Trader { get; set; } = "";
+        public string TraderRequirements { get; set; } = "";
     }
     public class TaskRequirementsModel
     {
@@ -53,5 +65,41 @@
     public class TasksGraphQLWrapper
     {
         public TasksWrapper? Data { get; set; }
+    }
+
+    public static class TaskModelExtensions
+    {
+        public static IEnumerable<TaskModelFlat> Flatten(this IEnumerable<TaskModel> tasks)
+        {
+            foreach (var task in tasks)
+            {
+                yield return new TaskModelFlat()
+                {
+                    Id = task.Id,
+                    Name = task.Name,
+                    MinPlayerLevel = task.MinPlayerLevel,
+                    Objectives = task.Objectives.Serialize(),
+                    TaskRequirements = task.TaskRequirements.Serialize(),
+                    Trader = task.Trader.Serialize(),
+                    TraderRequirements = task.TraderRequirements.Serialize(),
+                };
+            }
+        }
+        public static IEnumerable<TaskModel> Expand(this IEnumerable<TaskModelFlat> tasks)
+        {
+            foreach(var task in tasks)
+            {
+                yield return new TaskModel()
+                {
+                    Id = task.Id,
+                    Name = task.Name,
+                    MinPlayerLevel = task.MinPlayerLevel,
+                    Objectives = task.Objectives.Deserialize<ObjectiveModel[]>() ?? [],
+                    TaskRequirements = task.TaskRequirements.Deserialize<TaskRequirementsModel[]>() ?? [],
+                    Trader = task.Trader.Deserialize<TraderModel>() ?? new(),
+                    TraderRequirements = task.TraderRequirements.Deserialize<TraderRequirementsModel[]>() ?? [],
+                };
+            }
+        }
     }
 }

--- a/TarkovSauce.Client/Data/Models/Remote/TaskStatusBody.cs
+++ b/TarkovSauce.Client/Data/Models/Remote/TaskStatusBody.cs
@@ -2,7 +2,7 @@
 {
     public class TaskStatusBody
     {
-        public string? Id { get; private set; }
+        public string Id { get; private set; }
         public string State { get; private set; }
         private TaskStatusBody(string id, string newState)
         {

--- a/TarkovSauce.Client/Data/Models/Remote/TaskStatusBody.cs
+++ b/TarkovSauce.Client/Data/Models/Remote/TaskStatusBody.cs
@@ -1,8 +1,12 @@
-﻿namespace TarkovSauce.Client.Data.Models.Remote
+﻿using System.Text.Json.Serialization;
+
+namespace TarkovSauce.Client.Data.Models.Remote
 {
     public class TaskStatusBody
     {
+        [JsonPropertyName("id")]
         public string Id { get; private set; }
+        [JsonPropertyName("state")]
         public string State { get; private set; }
         private TaskStatusBody(string id, string newState)
         {

--- a/TarkovSauce.Client/Data/Providers/FleaSalesProvider.cs
+++ b/TarkovSauce.Client/Data/Providers/FleaSalesProvider.cs
@@ -23,7 +23,7 @@ namespace TarkovSauce.Client.Data.Providers
         {
             _httpClient = httpClient;
             _sqlService = sqlService;
-            Events.AddRange(sqlService.Get<FleaEventModel>());
+            //Events.AddRange(sqlService.Get<FleaEventModel>());
         }
 
         public async Task AppendExpiry(FleaExpiredeMessageEventArgs? args)

--- a/TarkovSauce.Client/Data/Providers/FleaSalesProvider.cs
+++ b/TarkovSauce.Client/Data/Providers/FleaSalesProvider.cs
@@ -34,7 +34,8 @@ namespace TarkovSauce.Client.Data.Providers
             {
                 Type = FleaEventType.Expired,
                 ItemName = item,
-                Quantity = args.ItemCount
+                Quantity = args.ItemCount,
+                Timestamp = DateTime.UnixEpoch.AddSeconds(args.Message.Timestamp).ToLocalTime()
             };
             Events.Add(ev);
             _sqlService.Insert(ev);
@@ -53,7 +54,8 @@ namespace TarkovSauce.Client.Data.Providers
                 ItemName = soldItem,
                 Currency = currency.Key,
                 Reward = currency.Value,
-                Quantity = args.SoldItemCount
+                Quantity = args.SoldItemCount,
+                Timestamp = DateTime.UnixEpoch.AddSeconds(args.Message.Timestamp).ToLocalTime()
             };
             Events.Add(ev);
             _sqlService.Insert(ev);
@@ -70,6 +72,7 @@ namespace TarkovSauce.Client.Data.Providers
         public int Quantity { get; set; }
         public string Currency { get; set; } = "";
         public int Reward { get; set; }
+        public DateTime Timestamp { get; set; }
     }
     public enum FleaEventType
     {

--- a/TarkovSauce.Client/Data/Providers/FleaSalesProvider.cs
+++ b/TarkovSauce.Client/Data/Providers/FleaSalesProvider.cs
@@ -1,5 +1,7 @@
-﻿using TarkovSauce.Client.Data.EventArgs;
+﻿using SQLite;
+using TarkovSauce.Client.Data.EventArgs;
 using TarkovSauce.Client.HttpClients;
+using TarkovSauce.Client.Services;
 
 namespace TarkovSauce.Client.Data.Providers
 {
@@ -9,21 +11,33 @@ namespace TarkovSauce.Client.Data.Providers
         Task AppendSale(FleaSoldMessageEventArgs? args);
         Task AppendExpiry(FleaExpiredeMessageEventArgs? args);
     }
-    public class FleaSalesProvider(ITarkovDevHttpClient _httpClient) : IFleaSalesProvider
+    public class FleaSalesProvider : IFleaSalesProvider
     {
+        private readonly ITarkovDevHttpClient _httpClient;
+        private readonly ISqlService _sqlService;
+
         public List<FleaEventModel> Events { get; } = [];
         public Action? OnStateChanged { get; set; }
+        
+        public FleaSalesProvider(ITarkovDevHttpClient httpClient, ISqlService sqlService)
+        {
+            _httpClient = httpClient;
+            _sqlService = sqlService;
+            Events.AddRange(sqlService.Get<FleaEventModel>());
+        }
 
         public async Task AppendExpiry(FleaExpiredeMessageEventArgs? args)
         {
             if (args is null) return;
             var item = (await _httpClient.GetItemNameBatch(args.ItemId))?.Data?.Items?.FirstOrDefault()?.Name ?? "Not Found";
-            Events.Add(new FleaEventModel()
+            var ev = new FleaEventModel()
             {
                 Type = FleaEventType.Expired,
                 ItemName = item,
                 Quantity = args.ItemCount
-            });
+            };
+            Events.Add(ev);
+            _sqlService.Insert(ev);
             OnStateChanged?.Invoke();
         }
 
@@ -32,7 +46,7 @@ namespace TarkovSauce.Client.Data.Providers
             if (args is null) return;
             var soldItem = (await _httpClient.GetItemNameBatch(args.SoldItemId))?.Data?.Items?.FirstOrDefault()?.Name ?? "Not Found";
             var currency = args.ReceivedItems.FirstOrDefault(f => !string.IsNullOrWhiteSpace(f.Key));
-            Events.Add(new FleaEventModel()
+            var ev = new FleaEventModel()
             {
                 Type = FleaEventType.Sale,
                 Buyer = args.Buyer,
@@ -40,12 +54,16 @@ namespace TarkovSauce.Client.Data.Providers
                 Currency = currency.Key,
                 Reward = currency.Value,
                 Quantity = args.SoldItemCount
-            });
+            };
+            Events.Add(ev);
+            _sqlService.Insert(ev);
             OnStateChanged?.Invoke();
         }
     }
     public class FleaEventModel
     {
+        [PrimaryKey, AutoIncrement]
+        public int Id { get; set; }
         public FleaEventType Type { get; set; }
         public string ItemName { get; set; } = "";
         public string Buyer { get; set; } = "";

--- a/TarkovSauce.Client/Data/Providers/RawLogProvider.cs
+++ b/TarkovSauce.Client/Data/Providers/RawLogProvider.cs
@@ -2,16 +2,18 @@
 {
     public interface IRawLogProvider : IProvider
     {
-        List<string> RawLogs { get; }
+        Queue<string> RawLogs { get; }
         void AppendLog(string message);
     }
     public class RawLogProvider : IRawLogProvider
     {
         public Action? OnStateChanged { get; set; }
-        public List<string> RawLogs { get; } = [];
+        public Queue<string> RawLogs { get; } = [];
         public void AppendLog(string message)
         {
-            RawLogs.Add(message);
+            if (RawLogs.Count > 1000)
+                RawLogs.Dequeue();
+            RawLogs.Enqueue(message);
             OnStateChanged?.Invoke();
         }
     }

--- a/TarkovSauce.Client/Data/Providers/TarkovTrackerLogsProvider.cs
+++ b/TarkovSauce.Client/Data/Providers/TarkovTrackerLogsProvider.cs
@@ -11,7 +11,8 @@
         public List<string> Logs { get; } = [];
         public void Log(string message)
         {
-
+            Logs.Add(message);
+            OnStateChanged?.Invoke();
         }
     }
 }

--- a/TarkovSauce.Client/HttpClients/TarkovDevHttpClient.cs
+++ b/TarkovSauce.Client/HttpClients/TarkovDevHttpClient.cs
@@ -1,5 +1,7 @@
-﻿using System.Net.Http.Json;
+﻿using Microsoft.Maui.Controls.PlatformConfiguration;
+using System.Net.Http.Json;
 using TarkovSauce.Client.Data.Models.Remote;
+using TarkovSauce.Client.Services;
 
 namespace TarkovSauce.Client.HttpClients
 {
@@ -8,24 +10,51 @@ namespace TarkovSauce.Client.HttpClients
         Task<ItemsGraphQLWrapper?> GetItemNameBatch(params string[] ids);
         Task<TasksGraphQLWrapper?> GetTasksBatch();
     }
-    public class TarkovDevHttpClient(HttpClient _httpClient) : ITarkovDevHttpClient
+    public class TarkovDevHttpClient(HttpClient _httpClient, ISqlService _sqlService) : ITarkovDevHttpClient
     {
         public async Task<ItemsGraphQLWrapper?> GetItemNameBatch(params string[] ids)
         {
+            var cache = _sqlService.GetWhere<ItemModel>(item => ids.Contains(item.Id));
+            if (cache.Any())
+            {
+                return new ItemsGraphQLWrapper()
+                {
+                    Data = new ItemsWrapper()
+                    {
+                        Items = cache.ToArray()
+                    }
+                };
+            }
+
             Dictionary<string, string> content = new()
             {
                 { "query", "{items(ids: [\"" + string.Join("\",\"", ids) + "\"]) { id name }}" }
             };
 
-            return await Post<ItemsGraphQLWrapper>(content);
+            var result = await Post<ItemsGraphQLWrapper>(content);
+            _sqlService.InsertAll(result?.Data?.Items);
+            return result;
         }
         public async Task<TasksGraphQLWrapper?> GetTasksBatch()
         {
+            var cache = _sqlService.Get<TaskModel>();
+            if (cache.Any())
+            {
+                return new TasksGraphQLWrapper()
+                {
+                    Data = new TasksWrapper()
+                    {
+                        Tasks = cache.ToArray()
+                    }
+                };
+            }
             Dictionary<string, string> content = new()
             {
                 { "query", "{\r\n  tasks {\r\n    id\r\n    name\r\n    minPlayerLevel\r\n    trader {\r\n      name\r\n      imageLink\r\n    }\r\n    taskRequirements {\r\n      task {\r\n        id\r\n      }\r\n      status\r\n    }\r\n    objectives {\r\n      id\r\n      type\r\n      description\r\n      maps {\r\n        normalizedName\r\n      }\r\n      ... on TaskObjectiveQuestItem {\r\n        requiredKeys {\r\n          name\r\n          shortName\r\n          gridImageLink\r\n        }\r\n      }\r\n      ... on TaskObjectiveItem {\r\n        item {\r\n          name\r\n          shortName\r\n        }\r\n        items {\r\n          name\r\n          shortName\r\n        }\r\n        count\r\n        foundInRaid\r\n      }\r\n      ... on TaskObjectiveShoot {\r\n        targetNames\r\n        count\r\n      }\r\n    }\r\n    traderRequirements {\r\n      trader {\r\n        name\r\n        imageLink\r\n      }\r\n      requirementType\r\n      compareMethod\r\n      value\r\n    }\r\n  }\r\n}" }
             };
-            return await Post<TasksGraphQLWrapper>(content);
+            var result = await Post<TasksGraphQLWrapper>(content);
+            _sqlService.InsertAll(result?.Data?.Tasks);
+            return result;
         }
         private async Task<TResult?> Post<TResult>(object content)
         {

--- a/TarkovSauce.Client/HttpClients/TarkovDevHttpClient.cs
+++ b/TarkovSauce.Client/HttpClients/TarkovDevHttpClient.cs
@@ -37,14 +37,14 @@ namespace TarkovSauce.Client.HttpClients
         }
         public async Task<TasksGraphQLWrapper?> GetTasksBatch()
         {
-            var cache = _sqlService.Get<TaskModel>();
+            var cache = _sqlService.Get<TaskModelFlat>();
             if (cache.Any())
             {
                 return new TasksGraphQLWrapper()
                 {
                     Data = new TasksWrapper()
                     {
-                        Tasks = cache.ToArray()
+                        Tasks = cache.Expand().ToArray()
                     }
                 };
             }
@@ -53,7 +53,7 @@ namespace TarkovSauce.Client.HttpClients
                 { "query", "{\r\n  tasks {\r\n    id\r\n    name\r\n    minPlayerLevel\r\n    trader {\r\n      name\r\n      imageLink\r\n    }\r\n    taskRequirements {\r\n      task {\r\n        id\r\n      }\r\n      status\r\n    }\r\n    objectives {\r\n      id\r\n      type\r\n      description\r\n      maps {\r\n        normalizedName\r\n      }\r\n      ... on TaskObjectiveQuestItem {\r\n        requiredKeys {\r\n          name\r\n          shortName\r\n          gridImageLink\r\n        }\r\n      }\r\n      ... on TaskObjectiveItem {\r\n        item {\r\n          name\r\n          shortName\r\n        }\r\n        items {\r\n          name\r\n          shortName\r\n        }\r\n        count\r\n        foundInRaid\r\n      }\r\n      ... on TaskObjectiveShoot {\r\n        targetNames\r\n        count\r\n      }\r\n    }\r\n    traderRequirements {\r\n      trader {\r\n        name\r\n        imageLink\r\n      }\r\n      requirementType\r\n      compareMethod\r\n      value\r\n    }\r\n  }\r\n}" }
             };
             var result = await Post<TasksGraphQLWrapper>(content);
-            _sqlService.InsertAll(result?.Data?.Tasks);
+            _sqlService.InsertAll(result?.Data?.Tasks?.Flatten());
             return result;
         }
         private async Task<TResult?> Post<TResult>(object content)

--- a/TarkovSauce.Client/HttpClients/TarkovTrackerHttpClient.cs
+++ b/TarkovSauce.Client/HttpClients/TarkovTrackerHttpClient.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using System.Text;
 using System.Text.Json;
 using TarkovSauce.Client.Data.Models.Remote;
 
@@ -60,7 +61,7 @@ namespace TarkovSauce.Client.HttpClients
             if (_token is null && await TestToken() is null)
                 return null;
             HttpRequestMessage request = CreateRequest(HttpMethod.Post, _baseUri + "/progress/tasks");
-            request.Content = new StringContent(body.Serialize());
+            request.Content = new StringContent(body.Serialize(), Encoding.UTF8, "application/json");
             HttpResponseMessage response = await _httpClient.SendAsync(request);
             string resultString = await response.Content.ReadAsStringAsync();
             if (response.IsSuccessStatusCode)

--- a/TarkovSauce.Client/HttpClients/TarkovTrackerHttpClient.cs
+++ b/TarkovSauce.Client/HttpClients/TarkovTrackerHttpClient.cs
@@ -58,6 +58,7 @@ namespace TarkovSauce.Client.HttpClients
         }
         public async Task<string?> SetTaskStatusBatch(List<TaskStatusBody> body)
         {
+            return "";
             if (_token is null && await TestToken() is null)
                 return null;
             HttpRequestMessage request = CreateRequest(HttpMethod.Post, _baseUri + "/progress/tasks");

--- a/TarkovSauce.Client/HttpClients/TarkovTrackerHttpClient.cs
+++ b/TarkovSauce.Client/HttpClients/TarkovTrackerHttpClient.cs
@@ -58,7 +58,6 @@ namespace TarkovSauce.Client.HttpClients
         }
         public async Task<string?> SetTaskStatusBatch(List<TaskStatusBody> body)
         {
-            return "";
             if (_token is null && await TestToken() is null)
                 return null;
             HttpRequestMessage request = CreateRequest(HttpMethod.Post, _baseUri + "/progress/tasks");

--- a/TarkovSauce.Client/MauiProgram.cs
+++ b/TarkovSauce.Client/MauiProgram.cs
@@ -27,20 +27,20 @@ namespace TarkovSauce.Client
             builder.Services.AddTSComponentServices();
             builder.Services.AddSingleton<StateContainer>();
 
+            var sqlService = new SqlService(AppDataManager.DatabaseFile);
             var appDataManager = new AppDataManager();
-            builder.Services.AddSingleton<IAppDataManager>(appDataManager);
-
             var tarkovDevHttpClient = new TarkovDevHttpClient(new HttpClient()
             {
                 BaseAddress = new Uri("https://api.tarkov.dev")
-            });
+            }, sqlService);
+
+            builder.Services.AddSingleton<IAppDataManager>(appDataManager);
             builder.Services.AddSingleton<ITarkovDevHttpClient>(provider => tarkovDevHttpClient);
             builder.Services.AddSingleton<ITarkovTrackerHttpClient>(provider
                 => new TarkovTrackerHttpClient(new HttpClient(),
                     provider.GetRequiredService<IConfiguration>(),
                     provider.GetRequiredService<ILogger<TarkovTrackerHttpClient>>()));
-            builder.Services.AddSingleton<ISqlService>(provider 
-                => new SqlService(AppDataManager.DatabaseFile));
+            builder.Services.AddSingleton<ISqlService>(sqlService);
 
             builder.Services.AddSingleton<IRawLogProvider, RawLogProvider>();
             builder.Services.AddSingleton<IFleaSalesProvider, FleaSalesProvider>();

--- a/TarkovSauce.Client/MauiProgram.cs
+++ b/TarkovSauce.Client/MauiProgram.cs
@@ -39,7 +39,8 @@ namespace TarkovSauce.Client
                 => new TarkovTrackerHttpClient(new HttpClient(),
                     provider.GetRequiredService<IConfiguration>(),
                     provider.GetRequiredService<ILogger<TarkovTrackerHttpClient>>()));
-
+            builder.Services.AddSingleton<ISqlService>(provider 
+                => new SqlService(AppDataManager.DatabaseFile));
 
             builder.Services.AddSingleton<IRawLogProvider, RawLogProvider>();
             builder.Services.AddSingleton<IFleaSalesProvider, FleaSalesProvider>();

--- a/TarkovSauce.Client/MauiProgram.cs
+++ b/TarkovSauce.Client/MauiProgram.cs
@@ -23,6 +23,10 @@ namespace TarkovSauce.Client
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                 });
 
+            using var loggerFactory = LoggerFactory.Create(loggingBuilder => loggingBuilder
+                .SetMinimumLevel(LogLevel.Trace)
+                .AddDebug());
+
             // Make statecontainer a thing
             var stateContainer = new StateContainer();
             var appData = new AppDataJson();
@@ -41,7 +45,7 @@ namespace TarkovSauce.Client
             builder.Services.AddTSComponentServices();
             builder.Services.AddSingleton(stateContainer);
 
-            var sqlService = new SqlService(AppDataManager.DatabaseFile);
+            var sqlService = new SqlService(AppDataManager.DatabaseFile, loggerFactory.CreateLogger<SqlService>());
             var appDataManager = new AppDataManager();
             var tarkovDevHttpClient = new TarkovDevHttpClient(new HttpClient()
             {

--- a/TarkovSauce.Client/MauiProgram.cs
+++ b/TarkovSauce.Client/MauiProgram.cs
@@ -60,6 +60,7 @@ namespace TarkovSauce.Client
                         appDataManager.WriteAppData(appdata);
                     }
                     options.LogPath = path;
+                    options.CheckpointPath = AppDataManager.CheckpointFile;
                     options.AddFile(new WatcherFile("application", "application.log"));
                     options.AddFile(new WatcherFile("notifications", "notifications.log"));
                 });

--- a/TarkovSauce.Client/Services/SqlService.cs
+++ b/TarkovSauce.Client/Services/SqlService.cs
@@ -26,7 +26,7 @@ namespace TarkovSauce.Client.Services
 
             _connection.CreateTable<FleaEventModel>();
             _connection.CreateTable<ItemModel>();
-            _connection.CreateTable<TaskModel>();
+            _connection.CreateTable<TaskModelFlat>();
         }
         public void Insert<T>(T? entity)
             where T : class

--- a/TarkovSauce.Client/Services/SqlService.cs
+++ b/TarkovSauce.Client/Services/SqlService.cs
@@ -1,0 +1,33 @@
+﻿
+using SQLite;
+using TarkovSauce.Client.Data.Providers;
+
+namespace TarkovSauce.Client.Services
+{
+    public interface ISqlService
+    {
+        void Insert<T>(T entity) where T
+            : class;
+        IEnumerable<T> Get<T>() where T
+            : new();
+    }
+    internal class SqlService : ISqlService
+    {
+        private readonly SQLiteConnection _connection;
+        public SqlService(string connectionString)
+        {
+            _connection = new SQLiteConnection(connectionString);
+            _connection.CreateTable<FleaEventModel>();
+        }
+        public void Insert<T>(T entity) where T 
+            : class
+        {
+            _connection.Insert(entity);
+        }
+        public IEnumerable<T> Get<T>() where T 
+            : new()
+        {
+            return _connection.Table<T>();
+        }
+    }
+}

--- a/TarkovSauce.Client/Services/SqlService.cs
+++ b/TarkovSauce.Client/Services/SqlService.cs
@@ -1,33 +1,72 @@
 ﻿
 using SQLite;
+using TarkovSauce.Client.Data.Models.Remote;
 using TarkovSauce.Client.Data.Providers;
 
 namespace TarkovSauce.Client.Services
 {
     public interface ISqlService
     {
-        void Insert<T>(T entity) where T
-            : class;
-        IEnumerable<T> Get<T>() where T
-            : new();
+        void Insert<T>(T? entity)
+            where T : class;
+        void InsertAll<T>(IEnumerable<T>? entities)
+            where T : class;
+        IEnumerable<T> Get<T>()
+            where T : new();
+        IEnumerable<T> GetWhere<T>(Func<T, bool> predicate)
+            where T : new();
     }
     internal class SqlService : ISqlService
     {
         private readonly SQLiteConnection _connection;
         public SqlService(string connectionString)
         {
-            _connection = new SQLiteConnection(connectionString);
+            _connection = new SQLiteConnection(connectionString,
+                SQLiteOpenFlags.SharedCache | SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite);
+
             _connection.CreateTable<FleaEventModel>();
+            _connection.CreateTable<ItemModel>();
+            _connection.CreateTable<TaskModel>();
         }
-        public void Insert<T>(T entity) where T 
-            : class
+        public void Insert<T>(T? entity)
+            where T : class
         {
-            _connection.Insert(entity);
+            if (entity is null) return;
+            try
+            {
+                _connection.Insert(entity);
+            }
+            catch { }//TODO log me
         }
-        public IEnumerable<T> Get<T>() where T 
-            : new()
+        public void InsertAll<T>(IEnumerable<T>? entities)
+            where T : class
         {
-            return _connection.Table<T>();
+            if (entities is null) return;
+            try
+            {
+                _connection.InsertAll(entities);
+            }
+            catch { }//TODO log me
+        }
+        public IEnumerable<T> Get<T>()
+            where T : new()
+        {
+            try
+            {
+                return _connection.Table<T>();
+            }
+            catch { }//TODO log me
+            return [];
+        }
+        public IEnumerable<T> GetWhere<T>(Func<T, bool> predicate)
+            where T : new()
+        {
+            try
+            {
+                return _connection.Table<T>().Where(predicate);
+            }
+            catch { }//TODO log me
+            return [];
         }
     }
 }

--- a/TarkovSauce.Client/TarkovSauce.Client.csproj
+++ b/TarkovSauce.Client/TarkovSauce.Client.csproj
@@ -48,6 +48,7 @@
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+        <PackageReference Include="sqlite-net-pcl" Version="1.8.116" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TarkovSauce.Client/Utils/AppDataManager.cs
+++ b/TarkovSauce.Client/Utils/AppDataManager.cs
@@ -12,6 +12,7 @@ namespace TarkovSauce.Client.Utils
     {
         public static string SettingsDirectory => FileSystem.Current.AppDataDirectory;
         public static string SettingsFile => Path.Combine(SettingsDirectory, "settings.json");
+        public static string DatabaseFile => Path.Combine(SettingsDirectory, "data.db");
         private readonly static JsonSerializerOptions _options = new() { WriteIndented = true };
         public AppDataJson GetAppData()
         {

--- a/TarkovSauce.Client/Utils/AppDataManager.cs
+++ b/TarkovSauce.Client/Utils/AppDataManager.cs
@@ -13,6 +13,7 @@ namespace TarkovSauce.Client.Utils
         public static string SettingsDirectory => FileSystem.Current.AppDataDirectory;
         public static string SettingsFile => Path.Combine(SettingsDirectory, "settings.json");
         public static string DatabaseFile => Path.Combine(SettingsDirectory, "data.db");
+        public static string CheckpointFile => Path.Combine(SettingsDirectory, "checkpoint");
         private readonly static JsonSerializerOptions _options = new() { WriteIndented = true };
         public AppDataJson GetAppData()
         {

--- a/TarkovSauce.Tests/Client/TestProviders.cs
+++ b/TarkovSauce.Tests/Client/TestProviders.cs
@@ -2,6 +2,7 @@
 using TarkovSauce.Client.Data.EventArgs;
 using TarkovSauce.Client.Data.Providers;
 using TarkovSauce.Client.HttpClients;
+using TarkovSauce.Client.Services;
 
 namespace TarkovSauce.Tests.Client
 {
@@ -27,8 +28,9 @@ namespace TarkovSauce.Tests.Client
         public async Task TestFleaSalesProvider_SoldEventTrigger()
         {
             var httpClient = Substitute.For<ITarkovDevHttpClient>();
+            var sqlService = Substitute.For<ISqlService>();
             bool isHit = false;
-            var provider = new FleaSalesProvider(httpClient);
+            var provider = new FleaSalesProvider(httpClient, sqlService);
             provider.OnStateChanged += () =>
             {
                 isHit = true;
@@ -44,8 +46,9 @@ namespace TarkovSauce.Tests.Client
         public async Task TestFleaSalesProvider_ExpiryEventTrigger()
         {
             var httpClient = Substitute.For<ITarkovDevHttpClient>();
+            var sqlService = Substitute.For<ISqlService>();
             bool isHit = false;
-            var provider = new FleaSalesProvider(httpClient);
+            var provider = new FleaSalesProvider(httpClient, sqlService);
             provider.OnStateChanged += () =>
             {
                 isHit = true;

--- a/TarkovSauce.Watcher/FolderFinder.cs
+++ b/TarkovSauce.Watcher/FolderFinder.cs
@@ -14,7 +14,8 @@ namespace TarkovSauce.Watcher
         }
 
         public string GetLatestLogFolder() => _folders.OrderByDescending(o => o.Key).FirstOrDefault().Value;
-
+        public List<string> GetLogFoldersNewerThan(DateTime dt) 
+            => _folders.Where(folder => folder.Key.Date >= dt.Date).Select(s => s.Value).ToList();
         private Dictionary<DateTime, string> GetLogFolders()
         {
             Dictionary<DateTime, string> folderDictionary = [];
@@ -30,7 +31,7 @@ namespace TarkovSauce.Watcher
                 DateTime folderDate = DateTime.ParseExact(dateTimeString, "yyyy.MM.dd_H-mm-ss", System.Globalization.CultureInfo.InvariantCulture);
                 folderDictionary.Add(folderDate, folderName);
             }
-            return folderDictionary.OrderByDescending(key => key.Key).ToDictionary(x => x.Key, x => x.Value);
+            return folderDictionary.OrderBy(key => key.Key).ToDictionary(x => x.Key, x => x.Value);
         }
 
         [GeneratedRegex(@"log_(?<timestamp>\d+\.\d+\.\d+_\d+-\d+-\d+)")]

--- a/TarkovSauce.Watcher/MessageFactory.cs
+++ b/TarkovSauce.Watcher/MessageFactory.cs
@@ -9,7 +9,6 @@ namespace TarkovSauce.Watcher
     {
         public void OnMessage(string name, string message)
         {
-            Debug.WriteLine(message);
             MatchCollection logMessages = LogPatternRegex().Matches(message);
             foreach (Match match in logMessages.Cast<Match>())
             {
@@ -31,7 +30,6 @@ namespace TarkovSauce.Watcher
         }
         public void OnError(string name, string message, Exception ex)
         {
-            Debug.WriteLine(ex);
             throw ex;
         }
 

--- a/TarkovSauce.Watcher/MessageFactory.cs
+++ b/TarkovSauce.Watcher/MessageFactory.cs
@@ -5,7 +5,7 @@ using TarkovSauce.Watcher.Interfaces;
 
 namespace TarkovSauce.Watcher
 {
-    internal partial class MessageFactory(List<IMessageListener> listeners) : IWatcherEventListener
+    internal partial class MessageFactory(List<IMessageListener> listeners, string checkpointPath) : IWatcherEventListener
     {
         public void OnMessage(string name, string message)
         {
@@ -27,6 +27,7 @@ namespace TarkovSauce.Watcher
                     listener.OnEvent(eventLine);
                 }
             }
+            File.WriteAllText(checkpointPath, DateTime.Now.ToString());
         }
         public void OnError(string name, string message, Exception ex)
         {

--- a/TarkovSauce.Watcher/MonitorExtensions.cs
+++ b/TarkovSauce.Watcher/MonitorExtensions.cs
@@ -18,16 +18,22 @@ namespace TarkovSauce.Watcher
             List<IMessageListener> listeners = [];
             listenersBuilder(services, listeners);
             monitor.RegisterListeners(listeners);
+            Task.Run(() =>
+            {
+                monitor.GoToCheckpoint();
+            });
         }
     }
     public interface IMonitorOptions
     {
         string LogPath { get; set; }
+        string CheckpointPath { get; set; }
         void AddFile(WatcherFile file);
     }
     internal class MonitorOptions : IMonitorOptions
     {
         public string LogPath { get; set; } = "";//"C:\\Battlestate Games\\Escape from Tarkov\\Logs"
+        public string CheckpointPath { get; set; } = "";
         public List<WatcherFile> Files { get; set; } = [];
 
         public void AddFile(WatcherFile file)

--- a/TarkovSauce.Watcher/MonitorExtensions.cs
+++ b/TarkovSauce.Watcher/MonitorExtensions.cs
@@ -18,10 +18,6 @@ namespace TarkovSauce.Watcher
             List<IMessageListener> listeners = [];
             listenersBuilder(services, listeners);
             monitor.RegisterListeners(listeners);
-            Task.Run(() =>
-            {
-                monitor.GoToCheckpoint();
-            });
         }
     }
     public interface IMonitorOptions


### PR DESCRIPTION
closes #14 

This PR introduces persistence via sqlite-pcl as a lightweight database. Currently we cache tarkov.dev items, tasks and flea entries only. 

This also introduces a new checkin mechanism which pulls in logs that are old but have not been read, and processes them. So in situations where you forget to turn on sauce before doing a few raids, when you run sauce again those raids will be updated. This mechanism only happens on startup.

Also introduces batch updates for tarkovtracker.io set requests at 30 second intervals. 